### PR TITLE
set NetworkVisualizationParam lineFullPath default to false

### DIFF
--- a/src/main/java/org/gridsuite/studyconfig/server/entities/NetworkVisualizationParamEntity.java
+++ b/src/main/java/org/gridsuite/studyconfig/server/entities/NetworkVisualizationParamEntity.java
@@ -32,7 +32,7 @@ public class NetworkVisualizationParamEntity {
     private UUID id;
 
     @Column(name = "line_full_path")
-    private Boolean lineFullPath = true;
+    private Boolean lineFullPath = false;
 
     @Column(name = "line_parallel_path")
     private Boolean lineParallelPath = true;


### PR DESCRIPTION
The detailed positions of all pylons in a line is a bit heavy (up to 50mb of data for a full country)