### PR TITLE
Clear column filter when columnFilterInfos is null

### DIFF
--- a/src/main/java/org/gridsuite/studyconfig/server/service/SpreadsheetConfigService.java
+++ b/src/main/java/org/gridsuite/studyconfig/server/service/SpreadsheetConfigService.java
@@ -330,6 +330,8 @@ public class SpreadsheetConfigService {
             filter.setFilterType(infos.filterType());
             filter.setFilterValue(infos.filterValue());
             filter.setFilterTolerance(infos.filterTolerance());
+        } else {
+            columnEntity.setColumnFilter(null);
         }
         columnEntity.setVisible(dto.visible());
 


### PR DESCRIPTION
## Summary
- Clear the `ColumnFilterEntity` on a column when the incoming DTO has no `columnFilterInfos`, instead of leaving the previously persisted filter in place.