### PR TITLE
Fix default spreadsheet formula for 2WT conductance and susceptance

### DIFF
--- a/src/main/resources/db/changelog/changesets/changelog_20260629T062144Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20260629T062144Z.xml
@@ -1,0 +1,15 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="lesoteti" id="1782714117979-1">
+        <update tableName="spreadsheet_column">
+            <column name="formula" value="unitToMicroUnit(g)" />
+            <where>formula = 'g'</where>
+        </update>
+    </changeSet>
+    <changeSet author="lesoteti" id="1782714117979-2">
+        <update tableName="spreadsheet_column">
+            <column name="formula" value="unitToMicroUnit(b)" />
+            <where>formula = 'b'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -116,3 +116,6 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20260619T162423Z.xml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20260629T062144Z.xml
+      relativeToChangelogFile: true

--- a/src/main/resources/default-spreadsheet-config-collection.json
+++ b/src/main/resources/default-spreadsheet-config-collection.json
@@ -570,7 +570,7 @@
           "name": "Magnetizing conductance (μS)",
           "type": "NUMBER",
           "precision": 1,
-          "formula": "g",
+          "formula": "unitToMicroUnit(g)",
           "dependencies": null,
           "id": "g"
         },
@@ -578,7 +578,7 @@
           "name": "Magnetizing susceptance (μS)",
           "type": "NUMBER",
           "precision": 1,
-          "formula": "b",
+          "formula": "unitToMicroUnit(b)",
           "dependencies": null,
           "id": "b"
         },


### PR DESCRIPTION
## PR Summary
we migrate all g and b as they must be in micro siemens in front not just those in two windings transformers


