### PR TITLE
Fix empty component library by default

### DIFF
--- a/src/main/java/org/gridsuite/studyconfig/server/entities/NetworkVisualizationParamEntity.java
+++ b/src/main/java/org/gridsuite/studyconfig/server/entities/NetworkVisualizationParamEntity.java
@@ -53,7 +53,7 @@ public class NetworkVisualizationParamEntity {
     private String substationLayout = "horizontal";
 
     @Column(name = "component_library")
-    private String componentLibrary = "";
+    private String componentLibrary = "GridSuiteAndConvergence";
 
     @Column(name = "nad_positions_generation_mode")
     private String nadPositionsGenerationMode = null;

--- a/src/main/resources/db/changelog/changesets/changelog_20260708T103000Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20260708T103000Z.xml
@@ -1,0 +1,9 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="bouhoursant" id="20260708T103000Z-1">
+        <update tableName="network_visualization_params">
+            <column name="component_library" value="GridSuiteAndConvergence"/>
+            <where>component_library IS NULL OR TRIM(component_library) = ''</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -119,3 +119,6 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20260629T062144Z.xml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20260708T103000Z.xml
+      relativeToChangelogFile: true

--- a/src/test/java/org/gridsuite/studyconfig/server/NetworkVisualizationParamEntityTest.java
+++ b/src/test/java/org/gridsuite/studyconfig/server/NetworkVisualizationParamEntityTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.studyconfig.server;
+
+import org.gridsuite.studyconfig.server.entities.NetworkVisualizationParamEntity;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
+ */
+class NetworkVisualizationParamEntityTest {
+
+    @Test
+    void testDefaultValues() {
+        NetworkVisualizationParamEntity entity = new NetworkVisualizationParamEntity();
+
+        assertThat(entity)
+                .satisfies(e -> {
+                    assertThat(e.getLineFullPath()).isFalse();
+                    assertThat(e.getLineParallelPath()).isTrue();
+                    assertThat(e.getLineFlowMode()).isEqualTo("feeders");
+                    assertThat(e.getMapManualRefresh()).isTrue();
+                    assertThat(e.getMapBaseMap()).isNull();
+                    assertThat(e.getDiagonalLabel()).isTrue();
+                    assertThat(e.getCenterLabel()).isFalse();
+                    assertThat(e.getSubstationLayout()).isEqualTo("horizontal");
+                    assertThat(e.getComponentLibrary()).isEqualTo("GridSuiteAndConvergence");
+                    assertThat(e.getNadPositionsGenerationMode()).isNull();
+                    assertThat(e.getStateEstimation()).isFalse();
+                });
+    }
+}


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
This parameter is left empty by default in the config but is then converted to Gridsuite_and_convergence by SLD server when empty.
https://github.com/powsybl/powsybl-single-line-diagram-server/blob/7a6106313c27634ddd71d90ba21bd788c0cc43bc/src/main/java/com/powsybl/sld/server/dto/SldRequestInfos.java#L40
As other parameters, set the default value directly in the default param. 
It makes it appear in the GUI :
<img width="1522" height="56" alt="image" src="https://github.com/user-attachments/assets/d6cf5203-7418-4bca-981f-314c06e3d849" />



